### PR TITLE
Wrong WM name

### DIFF
--- a/archinstall/default_profiles/desktops/hyperland.py
+++ b/archinstall/default_profiles/desktops/hyperland.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 class HyperlandProfile(XorgProfile):
 	def __init__(self):
-		super().__init__('Hyperland', ProfileType.DesktopEnv, description='')
+		super().__init__('Hyprland', ProfileType.DesktopEnv, description='')
 
 	@property
 	def packages(self) -> List[str]:


### PR DESCRIPTION
It should be Hyprland, not Hyperland

- This fix issue: <!-- #13, #15 and #16 for instance. Or ignore if you're adding new functionality -->

## PR Description:

<!-- Please describe what changes this PR introduces, a good example would be: https://github.com/archlinux/archinstall/pull/1377 -->

## Tests and Checks
- [x] I have tested the code!<br>
  <!-- 
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
